### PR TITLE
#53 Updates to V&V sequence diagram and readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ This is a [5GTANGO](http://www.5gtango.eu) component to coordinate the verificat
 
 ## What it is
 
-The Lifecycle Manager acts as the main executor for all V&V test activities. It is responsible for sequencing, executing and presenting corresponding test results. Although the LCM is responsible for overall test activity, execution of individual test plans is given over to the TEE.
-An outline of the architecture is given below
+The Lifecycle Manager (LCM) acts as the main executor for all V&V test activities. It is responsible for sequencing, executing and presenting corresponding test results. Although the LCM is responsible for overall test activity, execution of individual test plans is given over to the TEE.
+An outline of the architecture is shown below.
 
 <p align="center"><img src="https://raw.githubusercontent.com/wiki/sonata-nfv/tng-vnv-lcm/images/v40-release-lcm.png" /></p>
 
@@ -68,9 +68,9 @@ http://192.168.99.100:6100/tng-vnv-lcm/health
 
 No specific libraries are required for building this project. The following tools are used to build the component
 
-- `java (version 8)`
-- `grade (version 4.9)`
-- `docker (version 18.x)`
+- `Java JDK (8+)`
+- `gradle (4.9)`
+- `docker (18.x)`
 
 
 ## Contributing
@@ -79,7 +79,7 @@ Contributing to the Gatekeeper is really easy. You must:
 1. Clone [this repository](http://github.com/sonata-nfv/tng-vnv-lcm);
 1. Work on your proposed changes, preferably through submiting [issues](https://github.com/sonata-nfv/tng-vnv-lcm/issues);
 1. Submit a Pull Request;
-1. Follow/answer related [issues](https://github.com/sonata-nfv/tng-vnv-lcm/issues) (see Feedback-Chanel, below).
+1. Follow/answer related [issues](https://github.com/sonata-nfv/tng-vnv-lcm/issues) (see Feedback, below).
 
 
 ## License
@@ -94,6 +94,6 @@ The following lead developers are responsible for this repository and have admin
 * Guo Du ([mrduguo](https://github.com/mrduguo))
 * Felipe Vicens ([felipevicens](https://github.com/felipevicens))
 
-## Feedback-Chanels
+## Feedback
 
 Please use the [GitHub issues](https://github.com/sonata-nfv/tng-vnv-lcm/issues) and the 5GTANGO Verification and Validation group mailing list `5gtango-dev@list.atosresearch.eu` for feedback.

--- a/src/docs/developer-guide/extensions/overview/document-begin-text.adoc
+++ b/src/docs/developer-guide/extensions/overview/document-begin-text.adoc
@@ -1,4 +1,4 @@
-== Architecture
+== V&V Works
 
 [plantuml,tng-vnv-lcm]
 ----
@@ -6,32 +6,37 @@
 @startuml
 autonumber
 
-
-actor "SDk" as SDK
-participant "GateKeeper" as GK
-participant "Package" as PKG
+actor "SDK" as SDK
+participant "Gatekeeper" as GK
+participant "Un-Packager" as PKG
 database "Catalogue" as CAT
-box "Lifecyle Manager" #LightBlue
-	participant Scheduler
-	participant "Workflow" as WFE
+box "V&V Platform" #LightBlue
+	participant "LCM:Scheduler" as Scheduler
+	participant "LCM:Workflow Manager" as WFE
+	database "Local Catalogue" as LoCat
+    participant "Platform Adapter" as PA
+    participant "Test Execution Engine" as TEE
 end box
-participant "SP" as TPM
-participant "Test Execution Engine" as TEE
 database "Repositories" as TRR
+participant "SP" as TPM
 
-SDK -> PKG : upload package
-note right #FFAAAA: transparent proxy requests via GK was not indicated in this diagram
+SDK -> GK : upload package
+note right : transparent proxy requests via GK was not indicated in this diagram
+GK -> PKG : unpack package
 PKG -> CAT : create NS/Test
 CAT --> PKG : NS/Test UUID
 PKG -> GK : package updated
 
+opt schedule a test
+    GK -> Scheduler : plan a service test for a given package
+end
 GK -> Scheduler : package updated
 Scheduler -> GK : create session token
 opt if no package metadata passed in call back
     Scheduler -> CAT : read package metadata
 end
 loop for each NS
-      Scheduler -> CAT : get list of TESTs applicable to NS
+      Scheduler -> CAT : get list of Tests applicable to NS
 end
 loop for each TEST
       Scheduler -> CAT : get list of NS applicable to TEST
@@ -40,20 +45,23 @@ Scheduler --> Scheduler : build list of NS-Tests mapping
 
 
 loop for each NS-Tests mapping
-        Scheduler -> WFE : execute text execution plan
-        WFE -> TRR : save text execution plan: CREATED
-        WFE -> TPM : deploy NS
-        TPM --> WFE : NS runtime config
+        Scheduler -> WFE : execute test execution plan
+        WFE -> TRR : save test execution plan: CREATED
+        WFE -> PA : deploy NS
+        PA -> TPM : Onboard NS
+        PA \\- TPM : NS runtime config
+        WFE \\- PA : NS runtime config
         WFE -> TRR : update test execution plan: NS_DEPLOYED
         loop for each Test
               WFE -> TRR : create test suite result
               WFE -> TEE : run test
               TEE -> TEE : prepare, setup monitor, execute, gather and store result
               TEE --> WFE : test reuslt: SUCCESS|FAILED
-              WFE -> TRR : update test execution plan: test reuslt
+              WFE -> TRR : update test execution plan: test result
         end
         WFE -> TRR : update test execution plan: SUCCESS|FAILED
-        WFE -> TPM : tear down NS
+        WFE -> PA : teardown NS
+        PA -> TPM : teardown NS
 end
 
 @enduml


### PR DESCRIPTION
Address Issue #53

Update sequence diagram for V&V 
Split SDK to Package flow into 2 separate messages. 
Added Opt step 6 for 'schedule of test' 
Made Blue Box cover entire V&V rather than LCM 
Add LCM prefix to Scheduler and WorkflowManager (added manager suffix here also) 
changed text --> test in 2 places
